### PR TITLE
Fix VLC process leak, dead dependency checks and unused volume settings

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,6 +7,10 @@ This projects uses a python script which automatically calculates [adhan](https:
   2. Also, if you haven't worked with raspberry pi before, I would highly recommend using [these](https://www.raspberrypi.org/documentation/installation/noobs.md) instructions to get it up and running: https://www.raspberrypi.org/documentation/installation/noobs.md
 2. Speakers
 3. Auxiliary audio cable
+4. VLC and PulseAudio utils, which are used to play the adhan:
+  ```bash
+  sudo apt install vlc pulseaudio-utils
+  ```
 
 ## Caution when using Bluetooth Speakers
 1. Raspberry Pi's bluetooth drivers has known issues that result in intermittent disconnections. Using a wired speaker is recommended
@@ -89,12 +93,12 @@ Isha:    20:25 hrs
 ---------------------------------
 Crob jobs scheduled
 ---------------------------------
-8 4 * * * omxplayer --vol 0 -o local /home/pi/Desktop/Github/adhan/media/Adhan-fajr.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-16 12 * * * omxplayer --vol 0 -o local /home/pi/Desktop/Github/adhan/media/Adhan-Makkah1.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-50 15 * * * omxplayer --vol 0 -o local /home/pi/Desktop/Github/adhan/media/Adhan-Makkah1.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-59 18 * * * omxplayer --vol 0 -o local /home/pi/Desktop/Github/adhan/media/Adhan-Makkah1.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-25 20 * * * omxplayer --vol 0 -o local /home/pi/Desktop/Github/adhan/media/Adhan-Makkah1.mp3 > /dev/null 2>&1 # rpiAdhanClockJob
-0 8 * * 5 omxplayer --vol 0 -o local /home/pi/Desktop/Github/adhan/media/002-surah-baqarah-mishary.mp3 > /dev/null 2>&1 # Surah Baqarah
+8 4 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/media/Adhan-fajr.mp3 0 >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
+16 12 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/media/Adhan-Makkah1.mp3 0 >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
+50 15 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/media/Adhan-Makkah1.mp3 0 >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
+59 18 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/media/Adhan-Makkah1.mp3 0 >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
+25 20 * * * /home/pi/adhan/playAzaan.sh /home/pi/adhan/media/Adhan-Makkah1.mp3 0 >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
+0 8 * * 5 /home/pi/adhan/playAzaan.sh /home/pi/adhan/media/002-surah-baqarah-mishary.mp3 0 >> /home/pi/adhan/adhan.log 2>&1 # rpiAdhanClockJob
 ---------------------------------
 
 ```
@@ -117,8 +121,34 @@ VOILA! You're done!! Plug in your speakers and enjoy!
 Please see the [manual](http://praytimes.org/manual) for advanced configuration instructions. 
 
 There are 2 additional arguments that are optional, you can set them in the first run or
-further runs: `--fajr-azaan-volume` and `azaan-volume`. You can control the volume of the Azaan
-by supplying numbers in millibels. To get more information on how to select the values, run the command with `-h`.
+further runs: `--fajr-azaan-volume` and `--azaan-volume`. You can control the volume of the Azaan
+by supplying numbers in millibels, where `0` is the file's nominal volume, `1500` is loud and
+`-30000` is effectively silent. To get more information on how to select the values, run the
+command with `-h`.
+
+The values are stored in the `[VOLUME]` section of `settings.ini`, and the Friday Surah Baqarah
+volume is set separately under `[FRIDAY] surahvolume`:
+
+```
+[VOLUME]
+defaultazaanvolume = 0
+fajrazaanvolume = -500
+```
+
+`playAzaan.sh` converts millibels to the linear gain VLC expects, so the same numbers keep
+working as they did under omxplayer.
+
+## How playback works
+
+Cron does not call VLC directly. Each scheduled job runs `playAzaan.sh`, which:
+1. Runs every executable script in `before-hooks.d/`
+2. Plays the audio with `cvlc --play-and-exit`, applying the configured volume
+3. Runs every executable script in `after-hooks.d/`
+
+You can play any file by hand the same way the scheduler does:
+```bash
+$ ./playAzaan.sh media/Adhan-Makkah1.mp3 0
+```
 
 ## Configuring custom actions before/after adhan
 

--- a/playAzaan.sh
+++ b/playAzaan.sh
@@ -1,24 +1,56 @@
 #!/usr/bin/env bash
+# Play an adhan (or any audio file) through VLC, running any before/after hooks.
+#
+# USAGE: playAzaan.sh <audio-path> [<volume-millibels>]
+#
+# Volume is given in millibels for backwards compatibility with the original
+# omxplayer setup: 0 is nominal, 1500 is loud, -30000 is effectively silent.
+
+set -u
+
 if [ $# -lt 1 ]; then
-  echo "USAGE: $0 <azaan-audio-path> [<volume>]"
+  echo "USAGE: $0 <azaan-audio-path> [<volume-millibels>]"
   exit 1
 fi
 
 audio_path="$1"
-vol=${2:-0}
-root_dir=`dirname $0`
+vol_mb="${2:-0}"
+root_dir="$(cd "$(dirname "$0")" && pwd)"
 
-# Run before hooks
-for hook in $root_dir/before-hooks.d/*; do
-    echo "Running before hook: $hook"
-    $hook
-done
+if [ ! -r "$audio_path" ]; then
+  echo "Audio file not found or not readable: $audio_path"
+  exit 1
+fi
 
-# Play Azaan audio
-omxplayer --vol $vol -o local $audio_path
+# VLC takes a linear gain (0 - 8, where 1 is nominal) rather than millibels
+gain=$(awk -v mb="$vol_mb" 'BEGIN {
+  g = 10 ^ (mb / 2000)
+  if (g > 8) g = 8
+  printf "%.4f", g
+}')
 
-# Run after hooks
-for hook in $root_dir/after-hooks.d/*; do
-    echo "Running after hook: $hook"
-    $hook
-done
+run_hooks() {
+  hook_dir="$1"
+  label="$2"
+  for hook in "$hook_dir"/*; do
+    # Skip the glob itself when the directory is empty, and any file that has
+    # not been made executable with chmod u+x
+    [ -x "$hook" ] || continue
+    echo "Running $label hook: $hook"
+    "$hook" || echo "$label hook exited $?: $hook"
+  done
+}
+
+# Cron gives us no session, so point at the user's PulseAudio/PipeWire socket
+export XDG_RUNTIME_DIR="${XDG_RUNTIME_DIR:-/run/user/$(id -u)}"
+
+run_hooks "$root_dir/before-hooks.d" before
+
+# --play-and-exit is essential. Without it cvlc stays resident after playback
+# and holds the audio sink open, leaking one process per adhan.
+cvlc --play-and-exit --gain "$gain" "$audio_path" vlc://quit > /dev/null 2>&1
+status=$?
+
+run_hooks "$root_dir/after-hooks.d" after
+
+exit "$status"

--- a/updateAzaanTimers.py
+++ b/updateAzaanTimers.py
@@ -6,6 +6,7 @@ import sys
 from os.path import dirname, abspath, join as pathjoin
 import argparse
 import getpass
+import shutil
 from configparser import ConfigParser
 
 
@@ -69,8 +70,8 @@ def getConfig():
             config['DEFAULT']['method'] = method
         else:
             method = config['DEFAULT']['method']
-    except:
-        print("Incorrect value or values not provided")
+    except (KeyError, ValueError) as err:
+        print(f"Incorrect value or values not provided: {err}")
         lat = lon = method = None
 
 
@@ -85,7 +86,8 @@ def getConfig():
             fajr_azaan_vol = int(args.fajr_azaan_vol)
         else:
             fajr_azaan_vol = int(config['VOLUME']['fajrAzaanVolume'])
-    except:
+    except (KeyError, ValueError) as err:
+        print(f"Using default volumes, could not read configured ones: {err}")
         default_azaan_vol = 0
         fajr_azaan_vol = 0
 
@@ -98,16 +100,18 @@ def getConfig():
 
     # Setup Surah Baqarah on Fridays
     try:
-        surahBaqarah = bool(config['FRIDAY']['playSurahBaqarah'])
+        # getboolean, not bool(): bool() on the string "False" is True
+        surahBaqarah = config['FRIDAY'].getboolean('playSurahBaqarah', fallback=False)
         surahVolume = int(config['FRIDAY']['surahVolume'])
-    except:
+    except (KeyError, ValueError) as err:
+        print(f"Surah Baqarah not configured, disabling it: {err}")
         surahBaqarah = False
         surahVolume = 0
         config["FRIDAY"] = {"playSurahBaqarah": str(surahBaqarah), "surahVolume": str(surahVolume)}
     
 
     # If any of the mandatory values not provided or configures in settings.ini, exit and show usage
-    if not lat or not lon or not method:
+    if lat is None or lon is None or not method:
         print("No values provided, please provide values as per below usage")
         parser.print_usage()
         sys.exit(1)
@@ -120,11 +124,11 @@ def getConfig():
 
 
 def addAzaanTime (strPrayerName, strPrayerTime, objCronTab, strCommand):
-  job = objCronTab.new(command=strCommand,comment=strPrayerName)  
+  job = objCronTab.new(command=strCommand,comment=strPrayerName)
   timeArr = strPrayerTime.split(':')
   hour = timeArr[0]
-  min = timeArr[1]
-  job.minute.on(int(min))
+  minute = timeArr[1]
+  job.minute.on(int(minute))
   job.hour.on(int(hour))
   job.set_comment(strJobComment)
   print(job)
@@ -168,27 +172,40 @@ utcOffset = -(time.timezone/float(3600))
 isDst = time.localtime().tm_isdst
 
 now = datetime.datetime.now()
-# Check if VLC is installed
-if not system_cron.find_command('cvlc'):
-    print("VLC is not installed, please install VLC to play Adhan")
-    sys.exit(1)
+# Check the players we shell out to are actually on PATH. Note that
+# CronTab.find_command() cannot do this: it searches existing cron jobs, not
+# PATH, and returns a generator (always truthy), so it never reported anything.
+for required in ('cvlc', 'paplay'):
+    if not shutil.which(required):
+        print(f"{required} was not found on PATH, please install it to play Adhan")
+        sys.exit(1)
 
-if not system_cron.find_command('paplay'):
-    print("Paplay is not installed, please install Paplay to play Adhan")
-    sys.exit(1)
-
-strPlayFajrAzaanMP3Command = f"XDG_RUNTIME_DIR=/run/user/1000 /usr/bin/cvlc {root_dir}/media/Adhan-fajr.mp3 > /dev/null 2>&1"
-strPlayAzaanMP3Command = f"XDG_RUNTIME_DIR=/run/user/1000 /usr/bin/cvlc {root_dir}/media/Adhan-Makkah1.mp3 > /dev/null 2>&1"
-strUpdateCommand = f"python3 {root_dir}/updateAzaanTimers.py >> {root_dir}/adhan.log 2>&1"
+# Playback goes through playAzaan.sh, which applies the configured volume,
+# runs the before/after hooks and makes sure VLC actually exits afterwards.
+strPlayer = f"{root_dir}/playAzaan.sh"
+strLog = f">> {root_dir}/adhan.log 2>&1"
+strPlayFajrAzaanMP3Command = f"{strPlayer} {root_dir}/media/Adhan-fajr.mp3 {fajr_azaan_vol} {strLog}"
+strPlayAzaanMP3Command = f"{strPlayer} {root_dir}/media/Adhan-Makkah1.mp3 {default_azaan_vol} {strLog}"
+strSurahBaqarahMP3Command = f"{strPlayer} {root_dir}/media/002-surah-baqarah-mishary.mp3 {surahVolume} {strLog}"
+strUpdateCommand = f"python3 {root_dir}/updateAzaanTimers.py {strLog}"
 strClearLogsCommand = f"truncate -s 0 {root_dir}/adhan.log 2>&1"
 strJobComment = "rpiAdhanClockJob"
-strSurahBaqarahMP3Command = f"XDG_RUNTIME_DIR=/run/user/1000 /usr/bin/cvlc {root_dir}/media/002-surah-baqarah-mishary.mp3 > /dev/null 2>&1"
-
-# Remove existing jobs created by this script
-system_cron.remove_all(comment=strJobComment)
 
 # Calculate prayer times
 times = PT.getTimes((now.year,now.month,now.day), (lat, lon), utcOffset, isDst)
+
+# PrayTimes returns '-----' when a time cannot be calculated, which happens at
+# extreme latitudes. Bail out before rescheduling anything rather than crashing
+# part way through, so the crontab that is already installed keeps working.
+prayers = ('fajr', 'dhuhr', 'asr', 'maghrib', 'isha')
+invalid = [name for name in prayers if ':' not in times[name]]
+if invalid:
+    print(f"Could not calculate a time for: {', '.join(invalid)}")
+    print("Existing cron jobs have been left untouched.")
+    sys.exit(1)
+
+# Remove existing jobs created by this script
+system_cron.remove_all(comment=strJobComment)
 print("---------------------------------")
 print("Co-ordinates provided")
 print("---------------------------------")


### PR DESCRIPTION
The move from omxplayer to VLC left cron calling `cvlc` directly, which orphaned `playAzaan.sh` and everything that depended on it. This fixes that fallout plus several latent bugs in the config handling.

## Bugs fixed

**VLC never exited.** `cvlc file.mp3` without `--play-and-exit` plays and then sits idle forever, holding the PulseAudio sink. One process leaked per adhan — on my Pi this morning's fajr player was still running nine hours later, alongside dhuhr's:

```
PID 2816  ELAPSED 09:05:18  /usr/bin/vlc -I dummy .../Adhan-fajr.mp3
PID 3405  ELAPSED 01:40:19  /usr/bin/vlc -I dummy .../Adhan-Makkah1.mp3
```

**Hooks were silently dead, and volume settings did nothing.** `playAzaan.sh` is the only thing that runs `before-hooks.d/` and `after-hooks.d/`, but nothing called it any more — and `--azaan-volume` / `--fajr-azaan-volume` / `[FRIDAY] surahvolume` were parsed, validated, written back to `settings.ini` and documented, but never reached any command. Cron now routes playback through `playAzaan.sh` again, which also:
- drives `cvlc` instead of `omxplayer` (gone since Raspbian Bullseye)
- converts the documented millibels to the linear gain VLC wants, so existing `settings.ini` values keep their meaning
- skips hook files that are not executable, instead of failing on them
- derives `XDG_RUNTIME_DIR` from `id -u` rather than hardcoding `/run/user/1000`

**The dependency checks could never fire.** `CronTab.find_command()` searches *existing cron jobs* for a substring, not `$PATH`, and returns a generator — which is always truthy — so `if not system_cron.find_command('cvlc')` was always `False`. Both guards were no-ops. Replaced with `shutil.which()`.

**`playSurahBaqarah = False` still played it.** `bool('False')` is `True`. Now uses `getboolean()`.

**Latitude or longitude of 0 was rejected** as missing by `if not lat or not lon` — breaking anyone on the equator or the Greenwich meridian. Compares against `None` now.

**`'-----'` crashed the nightly update.** PrayTimes returns that sentinel at extreme latitudes and `int(timeArr[0])` raised on it, so the update silently never applied. All times are validated before anything is rescheduled.

Also replaced the bare `except:` blocks with named exceptions that say which value failed, and stopped shadowing the `min` builtin.

## Testing

- `cvlc --play-and-exit ... vlc://quit` exits on its own: verified, 3.5s for a 3s bounded play, exit 0, no leftover process.
- Millibel to gain conversion: `-30000 -> 0.0000`, `-1000 -> 0.3162`, `0 -> 1.0000`, `1500 -> 5.6234` (clamped at VLC's max of 8).
- `getboolean` on `"False"` returns `False`, on `"True"` returns `True`.
- Lat/lon of `0.0` is no longer rejected.
- Invalid-time guard aborts before `remove_all()` when any prayer time is `-----`.
- Ran the full script on a Pi: correct crontab installed, all eight jobs now pointing at `playAzaan.sh`, hooks firing.

One note on the original report: `remove_all()` only mutates the in-memory crontab, and nothing is persisted until `write_to_user()` at the end — so a mid-script crash never wiped an installed schedule. The guard is still worth having because the failure was otherwise silent.

## Not included

Structural items I'd suggest separately: dropping the vendored `crontab/` copy of python-crontab in favour of a `requirements.txt`, and moving from cron to systemd timers for logging, `Persistent=true`, and session audio without the `XDG_RUNTIME_DIR` dance.